### PR TITLE
Fix amount of rows

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ heights[currentRow] = [];
 
 fs.readFile(hgtPath, function(err, data) {
     if (err) console.warn(err);
-    var totalRows = Math.sqrt(data.length / 2);
+    var totalRows = Math.sqrt(data.length / 2) * 2;
     for (var i = 0; i < data.length; i++) {
         if (i % 2 === 0)
             heights[currentRow].push(data.readInt16BE(i));


### PR DESCRIPTION
Multiply the number of rows by 2 because each Int occupies 2 bytes instead of just 1 (We first divide the input length by two to get the amount of "values" but actually need the amount of "bytes" to know when to start the next row).
Before the output wouldn't be a square (with size 1201x1201 or 3601x3601) but a rectangle (2402x601), because the code would fill the array for the next row before finishing the current row (because of the "values"/"bytes" mixup)
